### PR TITLE
improved onExit() callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # signal-exit
 
-When you want to fire an no matter how a process exits:
+When you want to fire an event no matter how a process exits:
 
 * reaching the end of execution.
 * explicitly having `process.exit(code)` called.
@@ -11,7 +11,7 @@ Use `signal-exit`.
 ```js
 var onExit = require('signal-exit')
 
-onExit(function () {
+onExit(function (code, signal) {
   console.log('process exited!')
 })
 ```

--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ module.exports = function (cb) {
 
   var emittedExit = false
 
-  signals.forEach(function (sig) {
+  Object.keys(signals).forEach(function (sig) {
     var listener = function () {
       process.removeListener(sig, listener)
-      cb()
+      cb(process.exitCode || signals[sig], sig)
 
       process.kill(process.pid, sig)
     }
@@ -18,50 +18,54 @@ module.exports = function (cb) {
     } catch (er) {}
   })
 
-  process.on('exit', function () {
+  process.on('exit', function (code) {
     if (emittedExit) return
     emittedExit = true
-    return cb()
+    return cb(code, undefined)
   })
 }
 
-var signals = [
-  'SIGABRT',
-  'SIGALRM',
-  'SIGBUS',
+var signals = {
+  'SIGALRM': 142,
+  'SIGBUS': 138,
+  'SIGCLD': undefined,
+  'SIGEMT': undefined,
+  'SIGFPE': 136,
+  'SIGHUP': 129,
+  'SIGILL': 132,
+  'SIGINFO': undefined,
+  'SIGINT': 130, // CTRL^C
+  'SIGIOT': 134,
+  'SIGKILL': 137, // can't be caught, but let's keep it here.
+  'SIGLOST': undefined,
+  'SIGPIPE': 141,
+  'SIGPOLL': undefined,
+  'SIGPROF': 155,
+  'SIGPWR': undefined,
+  'SIGQUIT': 131,
+  'SIGSEGV': 139,
+  'SIGSTKFLT': undefined,
+  'SIGSYS': 140,
+  'SIGTERM': 143, // polite exit code, can be caught.
+  'SIGTRAP': 133,
+  'SIGTSTP': 146,
+  'SIGTTIN': 149,
+  'SIGTTOU': 150,
+  'SIGUNUSED': undefined,
+  'SIGUSR2': 159,
+  'SIGVTALRM': 154,
+  'SIGXCPU': 152,
+  'SIGXFSZ': 153
+}
+
+var nonFatalSignals = [
+  'SIGWINCH', // resize window.
+  'SIGUSR1', // debugger.
   'SIGCHLD',
-  'SIGCLD',
-  'SIGCONT',
-  'SIGEMT',
-  'SIGFPE',
-  'SIGHUP',
-  'SIGILL',
-  'SIGINFO',
-  'SIGINT',
-  'SIGIO',
-  'SIGIOT',
-  'SIGKILL',
-  'SIGLOST',
-  'SIGPIPE',
-  'SIGPOLL',
-  'SIGPROF',
-  'SIGPWR',
-  'SIGQUIT',
-  'SIGSEGV',
-  'SIGSTKFLT',
   'SIGSTOP',
-  'SIGSYS',
-  'SIGTERM',
-  'SIGTRAP',
-  'SIGTSTP',
-  'SIGTTIN',
-  'SIGTTOU',
-  'SIGUNUSED',
+  'SIGCONT',
+  'SIGIO',
   'SIGURG',
-  'SIGUSR1',
-  'SIGUSR2',
-  'SIGVTALRM',
-  'SIGWINCH',
-  'SIGXCPU',
-  'SIGXFSZ'
+  'SIGABRT',
+  'SIGURG' // out of band data.
 ]

--- a/test/fixtures/end-of-execution.js
+++ b/test/fixtures/end-of-execution.js
@@ -1,5 +1,5 @@
 var onSignalExit = require('../../')
 
-onSignalExit(function () {
-  console.log('reached end of execution')
+onSignalExit(function (code, signal) {
+  console.log('reached end of execution, ' + code + ', ' + signal)
 })

--- a/test/fixtures/exit.js
+++ b/test/fixtures/exit.js
@@ -1,7 +1,7 @@
 var onSignalExit = require('../../')
 
-onSignalExit(function () {
-  console.log('exited with process.exit()')
+onSignalExit(function (code, signal) {
+  console.log('exited with process.exit(), ' + code + ', ' + signal)
 })
 
 process.exit(32)

--- a/test/fixtures/sigint.js
+++ b/test/fixtures/sigint.js
@@ -1,7 +1,7 @@
 var onSignalExit = require('../../')
 
-onSignalExit(function () {
-  console.log('exited with sigint')
+onSignalExit(function (code, signal) {
+  console.log('exited with sigint, ' + code + ', ' + signal)
 })
 
 process.kill(process.pid, 'SIGINT')

--- a/test/fixtures/sigterm.js
+++ b/test/fixtures/sigterm.js
@@ -1,7 +1,7 @@
 var onSignalExit = require('../../')
 
-onSignalExit(function () {
-  console.log('exited with sigterm')
+onSignalExit(function (code, signal) {
+  console.log('exited with sigterm, ' + code + ', ' + signal)
 })
 
 process.kill(process.pid, 'SIGTERM')

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -10,7 +10,7 @@ describe('signal-exit', function () {
   it('receives an exit event when a process exits normally', function (done) {
     exec(process.execPath + ' ./test/fixtures/end-of-execution.js', function (err, stdout, stderr) {
       expect(err).to.equal(null)
-      stdout.should.match(/reached end of execution/)
+      stdout.should.match(/reached end of execution, 0, undefined/)
       done()
     })
   })
@@ -18,7 +18,7 @@ describe('signal-exit', function () {
   it('receives an exit event when a process is terminated with sigint', function (done) {
     exec(process.execPath + ' ./test/fixtures/sigint.js', function (err, stdout, stderr) {
       err.signal.should.equal('SIGINT')
-      stdout.should.match(/exited with sigint/)
+      stdout.should.match(/exited with sigint, 130, SIGINT/)
       done()
     })
   })
@@ -26,7 +26,7 @@ describe('signal-exit', function () {
   it('receives an exit event when a process is terminated with sigterm', function (done) {
     exec(process.execPath + ' ./test/fixtures/sigterm.js', function (err, stdout, stderr) {
       err.signal.should.equal('SIGTERM')
-      stdout.should.match(/exited with sigterm/)
+      stdout.should.match(/exited with sigterm, 143, SIGTERM/)
       done()
     })
   })
@@ -34,7 +34,7 @@ describe('signal-exit', function () {
   it('receives an exit event when process.exit() is called', function (done) {
     exec(process.execPath + ' ./test/fixtures/exit.js', function (err, stdout, stderr) {
       err.code.should.equal(32)
-      stdout.should.match(/exited with process\.exit()/)
+      stdout.should.match(/exited with process\.exit\(\), 32, undefined/)
       done()
     })
   })


### PR DESCRIPTION
* based on a feature request from @maxogden, we now return `code` and `signal` in the onExit callback.
* based on feedback from @iarna, I've started moving non-exity exit codes into their own list (fixes #1).
