### PR TITLE
Allow user-added listeners to block the exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ module.exports = function (cb) {
 
   Object.keys(signals).forEach(function (sig) {
     var listener = function () {
-      process.removeListener(sig, listener)
-      cb(process.exitCode || signals[sig], sig)
-
-      process.kill(process.pid, sig)
+      // If there are no other listeners, do the default action.
+      if (process.listeners(sig).length === 1) {
+        process.removeListener(sig, listener)
+        cb(process.exitCode || signals[sig], sig)
+        process.kill(process.pid, sig)
+      }
     }
 
     try {

--- a/test/fixtures/signal-listener.js
+++ b/test/fixtures/signal-listener.js
@@ -1,0 +1,21 @@
+var onSignalExit = require('../../')
+
+var calledListener = 0
+onSignalExit(function (code, signal) {
+  console.log('exited calledListener=%j, code=%j, signal=%j',
+              calledListener, code, signal)
+})
+
+process.on('SIGHUP', listener)
+process.kill(process.pid, 'SIGHUP')
+
+function listener () {
+  calledListener++
+  if (calledListener > 3) {
+    process.removeListener('SIGHUP', listener)
+  }
+
+  setTimeout(function () {
+    process.kill(process.pid, 'SIGHUP')
+  })
+}

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -1,7 +1,8 @@
 /* global describe, it */
 
 var exec = require('child_process').exec,
-  expect = require('chai').expect
+  expect = require('chai').expect,
+  assert = require('assert')
 
 require('chai').should()
 require('tap').mochaGlobals()
@@ -35,6 +36,15 @@ describe('signal-exit', function () {
     exec(process.execPath + ' ./test/fixtures/exit.js', function (err, stdout, stderr) {
       err.code.should.equal(32)
       stdout.should.match(/exited with process\.exit\(\), 32, undefined/)
+      done()
+    })
+  })
+
+  it('does not exit if user handles signal', function (done) {
+    exec(process.execPath + ' ./test/fixtures/signal-listener.js', function (err, stdout, stderr) {
+      assert.equal(err.code, null)
+      assert.equal(err.signal, 'SIGHUP')
+      assert.equal(stdout, 'exited calledListener=4, code=129, signal="SIGHUP"\n')
       done()
     })
   })


### PR DESCRIPTION
If a user adds a SIGHUP listener, then they can respond to that SIGHUP
and either process.exit() or not.  With this patch, that behavior is
restored.