### PR TITLE
monkey patch onExit execution order

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,69 @@
 var assert = require('assert')
 
-module.exports = function (cb) {
+module.exports = function (cb, opts) {
   assert.equal(typeof cb, 'function', 'a callback must be provided for exit handler')
 
-  var emittedExit = false
+  var emittedExit = false,
+    listenerMap = {},
+    listeners = []
+
+  opts = opts || {}
+  opts.minimumListeners = opts.maxListeners || 1
 
   Object.keys(signals).forEach(function (sig) {
     var listener = function () {
       // If there are no other listeners, do the default action.
-      if (process.listeners(sig).length === 1) {
+      if (process.listeners(sig).length <= opts.maxListeners) {
         process.removeListener(sig, listener)
         cb(process.exitCode || signals[sig], sig)
         process.kill(process.pid, sig)
       }
     }
 
+    listenerMap[sig] = listener
+    listeners.push(listener)
+
     try {
       process.on(sig, listener)
     } catch (er) {}
   })
 
-  process.on('exit', function (code) {
+  var listener = function (code) {
     if (emittedExit) return
     emittedExit = true
     return cb(code, undefined)
-  })
+  }
+
+  listenerMap['exit'] = listener
+  listeners.push(listener)
+  process.on('exit', listener)
+
+  if (opts.alwaysLast) monkeyPatchAddListener(listenerMap, listeners)
+}
+
+// in some cases we always want to ensure that the
+// onExit handler registered with signal-exit is
+// the last event handler to fire, e.g, for code coverage.
+function monkeyPatchAddListener (listenerMap, listeners) {
+  var events = Object.keys(listenerMap),
+    listener
+
+  process.on = process.addListener = (function (on) {
+    return function (ev, fn) {
+      for (var i = 0, event; (event = events[i]) !== undefined; i++) {
+        listener = listenerMap[event]
+
+        if (ev === event && listeners.indexOf(fn) === -1) {
+          process.removeListener(ev, listener)
+          var ret = on.call(process, ev, fn)
+          on.call(process, ev, listener)
+          return ret
+        }
+      }
+
+      return on.apply(this, arguments)
+    }
+  })(process.on)
 }
 
 var signals = {
@@ -60,7 +99,7 @@ var signals = {
   'SIGXFSZ': 153
 }
 
-var nonFatalSignals = [
+/* var nonFatalSignals = [
   'SIGWINCH', // resize window.
   'SIGUSR1', // debugger.
   'SIGCHLD',
@@ -70,4 +109,4 @@ var nonFatalSignals = [
   'SIGURG',
   'SIGABRT',
   'SIGURG' // out of band data.
-]
+] */

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "when you want process.on('exit') to fire when a process is killed with a signal.",
   "main": "index.js",
   "scripts": {
-    "test": "nyc tap ./test/*.js"
+    "test": "standard && nyc tap ./test/*.js"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/bcoe/signal-exit",
   "devDependencies": {
     "chai": "^2.3.0",
-    "nyc": "^2.0.0",
+    "nyc": "^2.0.3",
     "standard": "^3.9.0",
     "tap": "^1.0.4"
   }

--- a/test/fixtures/sigint.js
+++ b/test/fixtures/sigint.js
@@ -2,6 +2,6 @@ var onSignalExit = require('../../')
 
 onSignalExit(function (code, signal) {
   console.log('exited with sigint, ' + code + ', ' + signal)
-})
+}, {maxListeners: 2})
 
 process.kill(process.pid, 'SIGINT')

--- a/test/fixtures/signal-last.js
+++ b/test/fixtures/signal-last.js
@@ -1,0 +1,16 @@
+var onSignalExit = require('../../')
+var counter = 0
+
+onSignalExit(function (code, signal) {
+  counter++
+  console.log('last counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+}, {maxListeners: 2, alwaysLast: true})
+
+onSignalExit(function (code, signal) {
+  counter++
+  console.log('first counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+}, {maxListeners: 3})
+
+process.kill(process.pid, 'SIGHUP')

--- a/test/fixtures/signal-listener.js
+++ b/test/fixtures/signal-listener.js
@@ -4,7 +4,7 @@ var calledListener = 0
 onSignalExit(function (code, signal) {
   console.log('exited calledListener=%j, code=%j, signal=%j',
               calledListener, code, signal)
-})
+}, {maxListeners: 2})
 
 process.on('SIGHUP', listener)
 process.kill(process.pid, 'SIGHUP')

--- a/test/fixtures/sigterm.js
+++ b/test/fixtures/sigterm.js
@@ -2,6 +2,6 @@ var onSignalExit = require('../../')
 
 onSignalExit(function (code, signal) {
   console.log('exited with sigterm, ' + code + ', ' + signal)
-})
+}, {maxListeners: 2})
 
 process.kill(process.pid, 'SIGTERM')

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -48,4 +48,14 @@ describe('signal-exit', function () {
       done()
     })
   })
+
+  it('ensures that if alwaysLast=true, the handler is run last', function (done) {
+    exec(process.execPath + ' ./test/fixtures/signal-last.js', function (err, stdout, stderr) {
+      assert.equal(err.code, null)
+      assert.equal(err.signal, 'SIGHUP')
+      stdout.should.match(/first counter=1/)
+      stdout.should.match(/last counter=2/)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
In this update:

* `opts.alwaysLast` can be set, to ensure that the registered `onExit` event will always be the last exit event to fire. This is necessary to get accurate code coverage of `proces.on("exit")`.
* I've also added the option `opts.maxListeners`, this is mainly for in unit tests and allows us to ensure that `process.kill` is still executed, even when tests are instrumented with nyc.