### PR TITLE
Use global EventEmitter for listener management

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ When you want to fire an event no matter how a process exits:
 * reaching the end of execution.
 * explicitly having `process.exit(code)` called.
 * having `process.kill(pid, sig)` called.
+* receiving a fatal signal from outside the process
 
 Use `signal-exit`.
 
@@ -19,3 +20,19 @@ onExit(function (code, signal) {
   console.log('process exited!')
 })
 ```
+
+## API
+
+`var remove = onExit(function (code, signal) {}, options)`
+
+The return value of the function is a function that will remove the
+handler.
+
+Note that the function *only* fires for signals if the signal would
+cause the proces to exit.  That is, there are no other listeners, and
+it is a fatal signal.
+
+## Options
+
+* `alwaysLast`: Run this handler after any other signal or exit
+  handlers.  This causes `process.emit` to be monkeypatched.

--- a/signals.js
+++ b/signals.js
@@ -1,0 +1,49 @@
+// This is not the set of all possible signals.
+//
+// It IS, however, the set of all signals that trigger
+// an exit on either Linux or BSD systems.  Linux is a
+// superset of the signal names supported on BSD, and
+// the unknown signals just fail to register, so we can
+// catch that easily enough.
+//
+// Don't bother with SIGKILL.  It's uncatchable, which
+// means that we can't fire any callbacks anyway.
+//
+// If a user does happen to register a handler on a non-
+// fatal signal like SIGWINCH or something, and then
+// exit, it'll end up firing `process.emit('exit')`, so
+// the handler will be fired anyway.
+
+module.exports = [
+  'SIGABRT',
+  'SIGALRM',
+  'SIGBUS',
+  'SIGFPE',
+  'SIGHUP',
+  'SIGILL',
+  'SIGINT',
+  'SIGIOT',
+  'SIGPIPE',
+  'SIGPROF',
+  'SIGQUIT',
+  'SIGSEGV',
+  'SIGSYS',
+  'SIGTERM',
+  'SIGTRAP',
+  'SIGUSR1',
+  'SIGUSR2',
+  'SIGVTALRM',
+  'SIGXCPU',
+  'SIGXFSZ'
+]
+
+if (process.platform === 'linux') {
+  module.exports.push(
+    'SIGIO',
+    'SIGPOLL',
+    'SIGPWR',
+    'SIGSTKFLT',
+    'SIGUNUSED'
+  )
+}
+

--- a/test/fixtures/awaiter.js
+++ b/test/fixtures/awaiter.js
@@ -1,0 +1,35 @@
+var expectSignal = process.argv[2]
+
+if (!expectSignal || !isNaN(expectSignal)) {
+  throw new Error('signal not provided')
+}
+
+var onSignalExit = require('../../')
+
+onSignalExit(function (code, signal) {
+  // some signals don't always get recognized properly, because
+  // they have the same numeric code.
+  if (wanted[1] === true) {
+    signal = !!signal
+  }
+  console.log('%j', {
+    found: [ code, signal ],
+    wanted: wanted
+  })
+})
+
+var wanted
+switch (expectSignal) {
+  case 'SIGIOT':
+  case 'SIGUNUSED':
+  case 'SIGPOLL':
+    wanted = [ null, true ]
+    break
+  default:
+    wanted = [ null, expectSignal ]
+    break
+}
+
+console.error('want', wanted)
+
+setTimeout(function () {}, 1000)

--- a/test/fixtures/exit-last.js
+++ b/test/fixtures/exit-last.js
@@ -12,6 +12,3 @@ onSignalExit(function (code, signal) {
   console.log('first counter=%j, code=%j, signal=%j',
               counter, code, signal)
 })
-
-process.kill(process.pid, 'SIGHUP')
-setTimeout(function () {}, 1000)

--- a/test/fixtures/exiter.js
+++ b/test/fixtures/exiter.js
@@ -1,0 +1,45 @@
+var exit = process.argv[2] || 0
+
+var onSignalExit = require('../../')
+
+onSignalExit(function (code, signal) {
+  // some signals don't always get recognized properly, because
+  // they have the same numeric code.
+  if (wanted[1] === true) {
+    signal = !!signal
+  }
+  console.log('%j', {
+    found: [ code, signal ],
+    wanted: wanted
+  })
+})
+
+var wanted
+if (isNaN(exit)) {
+  switch (exit) {
+    case 'SIGIOT':
+    case 'SIGUNUSED':
+    case 'SIGPOLL':
+      wanted = [ null, true ]
+      break
+    default:
+      wanted = [ null, exit ]
+      break
+  }
+
+  try {
+    process.kill(process.pid, exit)
+    setTimeout(function () {}, 1000)
+  } catch (er) {
+    wanted = [ 0, null ]
+  }
+
+} else {
+  exit = +exit
+  wanted = [ exit, null ]
+  // If it's explicitly requested 0, then explicitly call it.
+  // "no arg" = "exit naturally"
+  if (exit || process.argv[2]) {
+    process.exit(exit)
+  }
+}

--- a/test/fixtures/load-unload.js
+++ b/test/fixtures/load-unload.js
@@ -1,0 +1,7 @@
+// just be silly with calling these functions a bunch
+// mostly just to get coverage of the guard branches
+var onSignalExit = require('../../')
+onSignalExit.load()
+onSignalExit.load()
+onSignalExit.unload()
+onSignalExit.unload()

--- a/test/fixtures/multiple-load.js
+++ b/test/fixtures/multiple-load.js
@@ -1,0 +1,52 @@
+// simulate cases where the module could be loaded from multiple places
+var onSignalExit = require('../../')
+var counter = 0
+
+onSignalExit(function (code, signal) {
+  counter++
+  console.log('last counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+}, {alwaysLast: true})
+
+onSignalExit(function (code, signal) {
+  counter++
+  console.log('first counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+})
+
+delete require('module')._cache[require.resolve('../../')]
+var onSignalExit = require('../../')
+
+onSignalExit(function (code, signal) {
+  counter++
+  console.log('last counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+}, {alwaysLast: true})
+
+onSignalExit(function (code, signal) {
+  counter++
+  console.log('first counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+})
+
+// Lastly, some that should NOT be shown
+delete require('module')._cache[require.resolve('../../')]
+var onSignalExit = require('../../')
+
+var unwrap = onSignalExit(function (code, signal) {
+  counter++
+  console.log('last counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+}, {alwaysLast: true})
+unwrap()
+
+unwrap = onSignalExit(function (code, signal) {
+  counter++
+  console.log('first counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+})
+
+unwrap()
+
+process.kill(process.pid, 'SIGHUP')
+setTimeout(function () {}, 1000)

--- a/test/fixtures/parent.js
+++ b/test/fixtures/parent.js
@@ -1,0 +1,51 @@
+var signal = process.argv[2]
+var gens = +process.argv[3] || 0
+
+if (!signal || !isNaN(signal)) {
+  throw new Error('signal not provided')
+}
+
+var spawn = require('child_process').spawn
+var file = require.resolve('./awaiter.js')
+console.error(process.pid, signal, gens)
+
+if (gens > 0) {
+  file = __filename
+}
+
+var child = spawn(process.execPath, [file, signal, gens - 1], {
+  stdio: [ 0, 'pipe', 'pipe' ]
+})
+
+if (!gens) {
+  child.stderr.on('data', function () {
+    child.kill(signal)
+  })
+}
+
+var result = ''
+child.stdout.on('data', function (c) {
+  result += c
+})
+
+child.on('close', function (code, sig) {
+  try {
+    result = JSON.parse(result)
+  } catch (er) {
+    console.log('%j', {
+      error: 'failed to parse json\n' + er.message,
+      result: result,
+      pid: process.pid,
+      child: child.pid,
+      gens: gens,
+      expect: [ null, signal ],
+      actual: [ code, sig ]
+    })
+    return
+  }
+  if (result.wanted[1] === true) {
+    sig = !!sig
+  }
+  result.external = result.external || [ code, sig ]
+  console.log('%j', result)
+})

--- a/test/fixtures/sigint.js
+++ b/test/fixtures/sigint.js
@@ -2,6 +2,10 @@ var onSignalExit = require('../../')
 
 onSignalExit(function (code, signal) {
   console.log('exited with sigint, ' + code + ', ' + signal)
-}, {maxListeners: 2})
+})
+
+// For some reason, signals appear to not always be fast enough
+// to come in before the process exits.  Just a few ticks needed.
+setTimeout(function () {}, 1000)
 
 process.kill(process.pid, 'SIGINT')

--- a/test/fixtures/sigkill.js
+++ b/test/fixtures/sigkill.js
@@ -1,0 +1,19 @@
+// SIGKILL can't be caught, and in fact, even trying to add the
+// listener will throw an error.
+// We handle that nicely.
+//
+// This is just here to get another few more lines of test
+// coverage.  That's also why it lies about being on a linux
+// platform so that we pull in those other event types.
+
+Object.defineProperty(process, 'platform', {
+  value: 'linux',
+  writable: false,
+  enumerable: true,
+  configurable: true
+})
+
+var signals = require('../../signals.js')
+signals.push('SIGKILL')
+var onSignalExit = require('../../')
+onSignalExit.load()

--- a/test/fixtures/signal-default.js
+++ b/test/fixtures/signal-default.js
@@ -1,0 +1,99 @@
+// This fixture is not used in any tests.  It is here merely as a way to
+// do research into the various signal behaviors on Linux and Darwin.
+// Run with no args to cycle through every signal type.  Run with a signal
+// arg to learn about how that signal behaves.
+
+if (process.argv[2]) {
+  child(process.argv[2])
+} else {
+  var signals = [
+    'SIGABRT',
+    'SIGALRM',
+    'SIGBUS',
+    'SIGCHLD',
+    'SIGCLD',
+    'SIGCONT',
+    'SIGEMT',
+    'SIGFPE',
+    'SIGHUP',
+    'SIGILL',
+    'SIGINFO',
+    'SIGINT',
+    'SIGIO',
+    'SIGIOT',
+    'SIGKILL',
+    'SIGLOST',
+    'SIGPIPE',
+    'SIGPOLL',
+    'SIGPROF',
+    'SIGPWR',
+    'SIGQUIT',
+    'SIGSEGV',
+    'SIGSTKFLT',
+    'SIGSTOP',
+    'SIGSYS',
+    'SIGTERM',
+    'SIGTRAP',
+    'SIGTSTP',
+    'SIGTTIN',
+    'SIGTTOU',
+    'SIGUNUSED',
+    'SIGURG',
+    'SIGUSR1',
+    'SIGUSR2',
+    'SIGVTALRM',
+    'SIGWINCH',
+    'SIGXCPU',
+    'SIGXFSZ'
+  ]
+
+  var spawn = require('child_process').spawn
+  ;(function test (signal) {
+    if (!signal) {
+      return
+    }
+    var child = spawn(process.execPath, [__filename, signal], { stdio: 'inherit' })
+    var timer = setTimeout(function () {
+      console.log('requires SIGCONT')
+      process.kill(child.pid, 'SIGCONT')
+    }, 750)
+
+    child.on('close', function (code, signal) {
+      console.log('code=%j signal=%j\n', code, signal)
+      clearTimeout(timer)
+      test(signals.pop())
+    })
+  })(signals.pop())
+}
+
+function child (signal) {
+  console.log('signal=%s', signal)
+
+  // set a timeout so we know whether or not the process terminated.
+  setTimeout(function () {
+    console.log('not terminated')
+  }, 200)
+
+  process.on('exit', function (code) {
+    console.log('emit exit code=%j', code)
+  })
+
+  try {
+    process.on(signal, function fn () {
+      console.log('signal is catchable', signal)
+      process.removeListener(signal, fn)
+      setTimeout(function () {
+        console.error('signal again')
+        process.kill(process.pid, signal)
+      })
+    })
+  } catch (er) {
+    console.log('not listenable')
+  }
+
+  try {
+    process.kill(process.pid, signal)
+  } catch (er) {
+    console.log('not issuable')
+  }
+}

--- a/test/fixtures/signal-listener.js
+++ b/test/fixtures/signal-listener.js
@@ -1,10 +1,12 @@
 var onSignalExit = require('../../')
 
+setTimeout(function () {})
+
 var calledListener = 0
 onSignalExit(function (code, signal) {
   console.log('exited calledListener=%j, code=%j, signal=%j',
               calledListener, code, signal)
-}, {maxListeners: 2})
+})
 
 process.on('SIGHUP', listener)
 process.kill(process.pid, 'SIGHUP')

--- a/test/fixtures/sigpipe.js
+++ b/test/fixtures/sigpipe.js
@@ -1,0 +1,8 @@
+var onSignalExit = require('../..')
+onSignalExit(function (code, signal) {
+  console.error('onSignalExit(%j,%j)', code, signal)
+})
+setTimeout(function () {
+  console.log('hello')
+})
+process.kill(process.pid, 'SIGPIPE')

--- a/test/fixtures/sigterm.js
+++ b/test/fixtures/sigterm.js
@@ -2,6 +2,8 @@ var onSignalExit = require('../../')
 
 onSignalExit(function (code, signal) {
   console.log('exited with sigterm, ' + code + ', ' + signal)
-}, {maxListeners: 2})
+})
+
+setTimeout(function () {}, 1000)
 
 process.kill(process.pid, 'SIGTERM')

--- a/test/fixtures/unwrap.js
+++ b/test/fixtures/unwrap.js
@@ -1,0 +1,37 @@
+// simulate cases where the module could be loaded from multiple places
+
+// Need to lie about this a little bit, since nyc uses this module
+// for its coverage wrap-up handling
+if (process.env.NYC_CWD) {
+  var emitter = process.__signal_exit_emitter__
+  var listeners = emitter.listeners('afterexit')
+  process.removeAllListeners('SIGHUP')
+  delete process.__signal_exit_emitter__
+  delete require('module')._cache[require.resolve('../../')]
+}
+
+var onSignalExit = require('../../')
+var counter = 0
+
+var unwrap = onSignalExit(function (code, signal) {
+  counter++
+  console.log('last counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+}, {alwaysLast: true})
+unwrap()
+
+unwrap = onSignalExit(function (code, signal) {
+  counter++
+  console.log('first counter=%j, code=%j, signal=%j',
+              counter, code, signal)
+})
+unwrap()
+
+if (global.__coverage__ && listeners && listeners.length) {
+  listeners.forEach(function (fn) {
+    onSignalExit(fn, { alwaysLast: true })
+  })
+}
+
+process.kill(process.pid, 'SIGHUP')
+setTimeout(function () {}, 1000)

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -7,13 +7,15 @@ var exec = require('child_process').exec,
 require('chai').should()
 require('tap').mochaGlobals()
 
+var onSignalExit = require('../')
+
 process.env.NYC_TEST = 'yep'
 
 describe('signal-exit', function () {
   it('receives an exit event when a process exits normally', function (done) {
     exec(process.execPath + ' ./test/fixtures/end-of-execution.js', function (err, stdout, stderr) {
       expect(err).to.equal(null)
-      stdout.should.match(/reached end of execution, 0, undefined/)
+      stdout.should.match(/reached end of execution, 0, null/)
       done()
     })
   })
@@ -21,7 +23,7 @@ describe('signal-exit', function () {
   it('receives an exit event when a process is terminated with sigint', function (done) {
     exec(process.execPath + ' ./test/fixtures/sigint.js', function (err, stdout, stderr) {
       assert(err)
-      stdout.should.match(/exited with sigint, 130, SIGINT/)
+      stdout.should.match(/exited with sigint, null, SIGINT/)
       done()
     })
   })
@@ -29,7 +31,7 @@ describe('signal-exit', function () {
   it('receives an exit event when a process is terminated with sigterm', function (done) {
     exec(process.execPath + ' ./test/fixtures/sigterm.js', function (err, stdout, stderr) {
       assert(err)
-      stdout.should.match(/exited with sigterm, 143, SIGTERM/)
+      stdout.should.match(/exited with sigterm, null, SIGTERM/)
       done()
     })
   })
@@ -37,7 +39,7 @@ describe('signal-exit', function () {
   it('receives an exit event when process.exit() is called', function (done) {
     exec(process.execPath + ' ./test/fixtures/exit.js', function (err, stdout, stderr) {
       err.code.should.equal(32)
-      stdout.should.match(/exited with process\.exit\(\), 32, undefined/)
+      stdout.should.match(/exited with process\.exit\(\), 32, null/)
       done()
     })
   })
@@ -45,17 +47,131 @@ describe('signal-exit', function () {
   it('does not exit if user handles signal', function (done) {
     exec(process.execPath + ' ./test/fixtures/signal-listener.js', function (err, stdout, stderr) {
       assert(err)
-      assert.equal(stdout, 'exited calledListener=4, code=129, signal="SIGHUP"\n')
+      assert.equal(stdout, 'exited calledListener=4, code=null, signal="SIGHUP"\n')
       done()
     })
   })
 
-  it('ensures that if alwaysLast=true, the handler is run last', function (done) {
+  it('ensures that if alwaysLast=true, the handler is run last (signal)', function (done) {
     exec(process.execPath + ' ./test/fixtures/signal-last.js', function (err, stdout, stderr) {
       assert(err)
       stdout.should.match(/first counter=1/)
       stdout.should.match(/last counter=2/)
       done()
+    })
+  })
+
+  it('ensures that if alwaysLast=true, the handler is run last (normal exit)', function (done) {
+    exec(process.execPath + ' ./test/fixtures/exit-last.js', function (err, stdout, stderr) {
+      assert.ifError(err)
+      stdout.should.match(/first counter=1/)
+      stdout.should.match(/last counter=2/)
+      done()
+    })
+  })
+
+  it('works when loaded multiple times', function (done) {
+    exec(process.execPath + ' ./test/fixtures/multiple-load.js', function (err, stdout, stderr) {
+      assert(err)
+      stdout.should.match(/first counter=1, code=null, signal="SIGHUP"/)
+      stdout.should.match(/first counter=2, code=null, signal="SIGHUP"/)
+      stdout.should.match(/last counter=3, code=null, signal="SIGHUP"/)
+      stdout.should.match(/last counter=4, code=null, signal="SIGHUP"/)
+      done()
+    })
+  })
+
+  it('removes handlers when fully unwrapped', function (done) {
+    exec(process.execPath + ' ./test/fixtures/unwrap.js', function (err, stdout, stderr) {
+      assert(err)
+      err.signal.should.equal('SIGHUP')
+      expect(err.code).to.equal(null)
+      done()
+    })
+  })
+
+  it('does not load() or unload() more than once', function (done) {
+    exec(process.execPath + ' ./test/fixtures/load-unload.js', function (err, stdout, stderr) {
+      assert.ifError(err)
+      done()
+    })
+  })
+
+  it('handles uncatchable signals with grace and poise', function (done) {
+    exec(process.execPath + ' ./test/fixtures/sigkill.js', function (err, stdout, stderr) {
+      assert.ifError(err)
+      done()
+    })
+  })
+
+  // These are signals that are aliases for other signals, so
+  // the result will sometimes be one of the others.  For these,
+  // we just verify that we GOT a signal, not what it is.
+  function weirdSignal (sig) {
+    return sig === 'SIGIOT' ||
+      sig === 'SIGIO' ||
+      sig === 'SIGSYS' ||
+      sig === 'SIGIOT' ||
+      sig === 'SIGABRT' ||
+      sig === 'SIGPOLL' ||
+      sig === 'SIGUNUSED'
+  }
+
+  // Exhaustively test every signal, and a few numbers.
+  var signals = onSignalExit.signals()
+  signals.concat('', 0, 1, 2, 3, 54).forEach(function (sig) {
+    var node = process.execPath
+    var js = require.resolve('./fixtures/exiter.js')
+    it('exits properly: ' + sig, function (done) {
+      exec(node + ' ' + js + ' ' + sig, function (err, stdout, stderr) {
+        if (sig) {
+          assert(err)
+          if (!isNaN(sig)) {
+            assert.equal(err.code, sig)
+          } else if (!weirdSignal(sig)) {
+            err.signal.should.equal(sig)
+          } else if (sig) {
+            assert(err.signal)
+          }
+        } else {
+          assert.ifError(err)
+        }
+
+        try {
+          var data = JSON.parse(stdout)
+        } catch (er) {
+          console.error('invalid json: %j', stdout, stderr)
+          throw er
+        }
+
+        if (weirdSignal(sig)) {
+          data.wanted[1] = true
+          data.found[1] = !!data.found[1]
+        }
+        assert.deepEqual(data.found, data.wanted)
+        done()
+      })
+    })
+  })
+
+  signals.forEach(function (sig) {
+    var node = process.execPath
+    var js = require.resolve('./fixtures/parent.js')
+    it('exits properly: (external sig) ' + sig, function (done) {
+      var cmd = node + ' ' + js + ' ' + sig
+      exec(cmd, function (err, stdout, stderr) {
+        assert.ifError(err)
+        try {
+          var data = JSON.parse(stdout)
+        } catch (er) {
+          console.error('invalid json: %j', stdout, stderr)
+          throw er
+        }
+
+        assert.deepEqual(data.found, data.wanted)
+        assert.deepEqual(data.external, data.wanted)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
Note: this is a breaking change requiring a major version bump.

From an API perspective, the biggest change is that the onExit callback
is not provided with the exit code corresponding to `127 + signal code`.
The reason for this is the same as for why it is not provided in Node's
ChildProcess close & exit events: the numbers vary across operating
systems, and are set in libc.  Thus, it's easier to just return `null`
as the exit code in those cases, and provide the signal only.

Instead of adding handlers directly to all of the signals, and using the
maxListeners option, with this change only a single emitter is used, so
that we only ever add 1 signal handler per signal.

In order to handle cases where the module might be loaded multiple
times, the emitter is hung on the process object at
`process.__signal_exit_emitter__`.  This object then has a `count`
property which keeps track of the number of times signal-exit has loaded
handlers.

The onSignalExit function now returns an `unwrap` method which will
remove the handler that the user provided.  When all handlers are
removed, it also then removed all of the signal event handlers and
process.exit handler.

Getting accurate coverage of this module required jumping through a few
hoops.  The unwrap tests in particular have to do some bizarre things to
pull nyc's handlers out of the way (and then re-add them later).  And,
any of the lines in the direct stack of emitting the `afterexit` event
will never be coverage-friendly, since they cannot complete until after
coverage has been finalized and written out.

With a few ignored lines and dirty tricks, however, coverage is 100%.

The biggest downside to this approach is that it does rely on a global
object hung on process.  At the very least, it's an extremely simple
shared interface, and EventEmitter is one of the most stable
abstractions in Node.