### PR TITLE
pretty ugly monkey-patch of process.reallyExit to handle multiple exit(n) calls

### DIFF
--- a/test/fixtures/change-code-expect.json
+++ b/test/fixtures/change-code-expect.json
@@ -1,0 +1,800 @@
+{
+  "explicit 0 nochange sigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "explicit 0 nochange nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "explicit 0 change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit 0 change nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit 0 code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "explicit 0 code nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "explicit 0 twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit 0 twice nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit 0 twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "explicit 0 twicecode nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "explicit 2 nochange sigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 2,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "second code=2"
+    ]
+  },
+  "explicit 2 nochange nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 2,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "second code=2"
+    ]
+  },
+  "explicit 2 change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "explicit 2 change nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "explicit 2 code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "second code=2"
+    ]
+  },
+  "explicit 2 code nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "second code=2"
+    ]
+  },
+  "explicit 2 twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "explicit 2 twice nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "explicit 2 twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "explicit 2 twicecode nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "explicit null nochange sigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "explicit null nochange nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "explicit null change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit null change nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit null code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "explicit null code nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "explicit null twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit null twice nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "explicit null twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "explicit null twicecode nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "code 0 nochange sigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "code 0 nochange nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "code 0 change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code 0 change nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code 0 code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "code 0 code nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "code 0 twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code 0 twice nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code 0 twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "code 0 twicecode nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "code 2 nochange sigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 2,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "second code=2"
+    ]
+  },
+  "code 2 nochange nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 2,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "second code=2"
+    ]
+  },
+  "code 2 change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "code 2 change nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "code 2 code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "second code=2"
+    ]
+  },
+  "code 2 code nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "second code=2"
+    ]
+  },
+  "code 2 twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "code 2 twice nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5"
+    ]
+  },
+  "code 2 twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "code 2 twicecode nosigexit": {
+    "code": 2,
+    "signal": null,
+    "exitCode": 2,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=2",
+      "set code from 2 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "code null nochange sigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "code null nochange nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "code null change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code null change nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code null code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "code null code nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "code null twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code null twice nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "code null twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "code null twicecode nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "normal 0 nochange sigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "normal 0 nochange nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 0,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "second code=0"
+    ]
+  },
+  "normal 0 change sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "normal 0 change nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "normal 0 code sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "normal 0 code nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "second code=0"
+    ]
+  },
+  "normal 0 twice sigexit": {
+    "code": 5,
+    "signal": null,
+    "exitCode": 5,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "normal 0 twice nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 5,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5"
+    ]
+  },
+  "normal 0 twicecode sigexit": {
+    "code": 6,
+    "signal": null,
+    "exitCode": 6,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  },
+  "normal 0 twicecode nosigexit": {
+    "code": 0,
+    "signal": null,
+    "exitCode": 0,
+    "actualCode": 6,
+    "actualSignal": null,
+    "stderr": [
+      "first code=0",
+      "set code from 0 to 5",
+      "set code from 5 to 6"
+    ]
+  }
+}

--- a/test/fixtures/change-code.js
+++ b/test/fixtures/change-code.js
@@ -1,0 +1,96 @@
+if (process.argv.length === 2) {
+  var types = [ 'explicit', 'code', 'normal' ]
+  var codes = [ 0, 2, 'null' ]
+  var changes = [ 'nochange', 'change', 'code', 'twice', 'twicecode']
+  var handlers = [ 'sigexit', 'nosigexit' ]
+  var opts = []
+  types.forEach(function (type) {
+    var testCodes = type === 'normal' ? [ 0 ] : codes
+    testCodes.forEach(function (code) {
+      changes.forEach(function (change) {
+        handlers.forEach(function (handler) {
+          opts.push([type, code, change, handler].join(' '))
+        })
+      })
+    })
+  })
+
+  var results = {}
+
+  var exec = require('child_process').exec
+  run(opts.shift())
+} else {
+  var type = process.argv[2]
+  var code = +process.argv[3]
+  var change = process.argv[4]
+  var sigexit = process.argv[5] !== 'nosigexit'
+
+  if (sigexit) {
+    var onSignalExit = require('../../')
+    onSignalExit(listener)
+  } else {
+    process.on('exit', listener)
+  }
+
+  process.on('exit', function (code) {
+    console.error('first code=%j', code)
+  })
+
+  if (change !== 'nochange') {
+    process.once('exit', function (code) {
+      console.error('set code from %j to %j', code, 5)
+      if (change === 'code' || change === 'twicecode') {
+        process.exitCode = 5
+      } else {
+        process.exit(5)
+      }
+    })
+    if (change === 'twicecode' || change === 'twice') {
+      process.once('exit', function (code) {
+        code = process.exitCode || code
+        console.error('set code from %j to %j', code, code + 1)
+        process.exit(code + 1)
+      })
+    }
+  }
+
+  process.on('exit', function (code) {
+    console.error('second code=%j', code)
+  })
+
+  if (type === 'explicit') {
+    if (code || code === 0) {
+      process.exit(code)
+    } else {
+      process.exit()
+    }
+  } else if (type === 'code') {
+    process.exitCode = +code || 0
+  }
+}
+
+function listener (code, signal) {
+  signal = signal || null
+  console.log('%j', { code: code, signal: signal, exitCode: process.exitCode || 0 })
+}
+
+function run (opt) {
+  console.error(opt)
+  exec(process.execPath + ' ' + __filename + ' ' + opt, function (err, stdout, stderr) {
+    var res = JSON.parse(stdout)
+    if (err) {
+      res.actualCode = err.code
+      res.actualSignal = err.signal
+    } else {
+      res.actualCode = 0
+      res.actualSignal = null
+    }
+    res.stderr = stderr.trim().split('\n')
+    results[opt] = res
+    if (opts.length) {
+      run(opts.shift())
+    } else {
+      console.log(JSON.stringify(results, null, 2))
+    }
+  })
+}

--- a/test/multi-exit.js
+++ b/test/multi-exit.js
@@ -1,0 +1,50 @@
+var exec = require('child_process').exec,
+  t = require('tap')
+
+var fixture = require.resolve('./fixtures/change-code.js')
+var expect = require('./fixtures/change-code-expect.json')
+
+// process.exit(code), process.exitCode = code, normal exit
+var types = [ 'explicit', 'code', 'normal' ]
+
+// initial code that is set.  Note, for 'normal' exit, there's no
+// point doing these, because we just exit without modifying code
+var codes = [ 0, 2, 'null' ]
+
+// do not change, change to 5 with exit(), change to 5 with exitCode,
+// change to 5 and then to 2 with exit(), change twice with exitcode
+var changes = [ 'nochange', 'change', 'code', 'twice', 'twicecode']
+
+// use signal-exit, use process.on('exit')
+var handlers = [ 'sigexit', 'nosigexit' ]
+
+var opts = []
+types.forEach(function (type) {
+  var testCodes = type === 'normal' ? [0] : codes
+  testCodes.forEach(function (code) {
+    changes.forEach(function (change) {
+      handlers.forEach(function (handler) {
+        opts.push([type, code, change, handler].join(' '))
+      })
+    })
+  })
+})
+
+opts.forEach(function (opt) {
+  t.test(opt, function (t) {
+    var cmd = process.execPath + ' ' + fixture + ' ' + opt
+    exec(cmd, function (err, stdout, stderr) {
+      var res = JSON.parse(stdout)
+      if (err) {
+        res.actualCode = err.code
+        res.actualSignal = err.signal
+      } else {
+        res.actualCode = 0
+        res.actualSignal = null
+      }
+      res.stderr = stderr.trim().split('\n')
+      t.same(res, expect[opt])
+      t.end()
+    })
+  })
+})

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -105,5 +105,4 @@ describe('signal-exit', function () {
       done()
     })
   })
-
 })


### PR DESCRIPTION
Ugh, this is so terrible, but I don't see another way.

But, by taking this approach, it makes it so that the code that the process *really actually exits with* is the one sent to `signal-exit`'s handler.

The coverage report says that `process.reallyExit` isn't being covered, but that can't be right, since the process does really exit.  A `console.error` statement placed in the function verifies this.