### PR TITLE
make behavior consistent between Linux and OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/bcoe/signal-exit",
   "devDependencies": {
     "chai": "^2.3.0",
+    "code-to-signal": "^1.0.2",
     "coveralls": "^2.11.2",
     "nyc": "^2.1.2",
     "standard": "^3.9.0",

--- a/test/all-integration-test.js
+++ b/test/all-integration-test.js
@@ -1,7 +1,8 @@
 /* global describe, it */
 
-var exec = require('child_process').exec,
-  assert = require('assert')
+var exec = require('child_process').exec
+var assert = require('assert')
+var codeToSignal = require('code-to-signal')
 
 require('chai').should()
 require('tap').mochaGlobals()
@@ -33,14 +34,16 @@ describe('all-signals-integration-test', function () {
       if (process.env.TRAVIS && sig === 'SIGUSR1') return done()
 
       exec(node + ' ' + js + ' ' + sig, function (err, stdout, stderr) {
+        codeToSignal.shimError(err)
+
         if (sig) {
           assert(err)
           if (!isNaN(sig)) {
             assert.equal(err.code, sig)
           } else if (!weirdSignal(sig)) {
-            if (!process.env.TRAVIS) err.signal.should.equal(sig)
+            err.signal.should.equal(sig)
           } else if (sig) {
-            if (!process.env.TRAVIS) assert(err.signal)
+            assert(err.signal)
           }
         } else {
           assert.ifError(err)

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -1,8 +1,9 @@
 /* global describe, it */
 
-var exec = require('child_process').exec,
-  expect = require('chai').expect,
-  assert = require('assert')
+var exec = require('child_process').exec
+var expect = require('chai').expect
+var assert = require('assert')
+var codeToSignal = require('code-to-signal')
 
 require('chai').should()
 require('tap').mochaGlobals()
@@ -81,13 +82,10 @@ describe('signal-exit', function () {
   // TODO: test on a few non-OSX machines.
   it('removes handlers when fully unwrapped', function (done) {
     exec(process.execPath + ' ./test/fixtures/unwrap.js', function (err, stdout, stderr) {
-      // on Travis CI no err.signal is populated but
-      // err.code is 129 (which I think tends to be SIGHUP).
-      var expectedCode = process.env.TRAVIS ? 129 : null
+      codeToSignal.shimError(err)
 
       assert(err)
-      if (!process.env.TRAVIS) err.signal.should.equal('SIGHUP')
-      expect(err.code).to.equal(expectedCode)
+      err.signal.should.equal('SIGHUP')
       done()
     })
   })


### PR DESCRIPTION
Shims the error object returned by exec, to make behavior consistent between OSX and Linux.

See #14, https://github.com/isaacs/spawn-wrap/pull/5, https://github.com/bcoe/code-to-signal