### PR TITLE
Use /bin/bash as the exec shell on Unixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 nyc_output
 coverage
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-- '0.12'
-- '0.10'
-- iojs
-after_success: npm run coverage
+  - '0.12'
+  - '4'
+  - '5'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "when you want to fire an event no matter how a process exits.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && nyc tap --timeout=240 ./test/*.js",
+    "posttest": "standard",
+    "test": "tap --timeout=240 ./test/*.js --cov",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "coveralls": "^2.11.2",
-    "nyc": "^2.1.2",
+    "nyc": "^5.1.0",
     "standard": "^3.9.0",
-    "tap": "1.0.4"
+    "tap": "^2.3.5"
   }
 }

--- a/test/all-integration-test.js
+++ b/test/all-integration-test.js
@@ -1,7 +1,8 @@
 /* global describe, it */
 
 var exec = require('child_process').exec,
-  assert = require('assert')
+  assert = require('assert'),
+  shell = process.platform === 'win32' ? null : { shell: '/bin/bash' }
 
 require('chai').should()
 require('tap').mochaGlobals()
@@ -32,7 +33,8 @@ describe('all-signals-integration-test', function () {
       // travis has issues with SIGUSR1 on Node 0.x.10.
       if (process.env.TRAVIS && sig === 'SIGUSR1') return done()
 
-      exec(node + ' ' + js + ' ' + sig, function (err, stdout, stderr) {
+      var cmd = node + ' ' + js + ' ' + sig
+      exec(cmd, shell, function (err, stdout, stderr) {
         if (sig) {
           assert(err)
           if (!isNaN(sig)) {
@@ -71,7 +73,7 @@ describe('all-signals-integration-test', function () {
       if (process.env.TRAVIS && sig === 'SIGUSR1') return done()
 
       var cmd = node + ' ' + js + ' ' + sig
-      exec(cmd, function (err, stdout, stderr) {
+      exec(cmd, shell, function (err, stdout, stderr) {
         assert.ifError(err)
         try {
           var data = JSON.parse(stdout)

--- a/test/all-integration-test.js
+++ b/test/all-integration-test.js
@@ -30,8 +30,8 @@ describe('all-signals-integration-test', function () {
     var node = process.execPath
     var js = require.resolve('./fixtures/exiter.js')
     it('exits properly: ' + sig, function (done) {
-      // travis has issues with SIGUSR1 on Node 0.x.10.
-      if (process.env.TRAVIS && sig === 'SIGUSR1') return done()
+      // issues with SIGUSR1 on Node 0.10.x
+      if (process.version.match(/^v0\.10\./) && sig === 'SIGUSR1') return done()
 
       var cmd = node + ' ' + js + ' ' + sig
       exec(cmd, shell, function (err, stdout, stderr) {
@@ -40,9 +40,9 @@ describe('all-signals-integration-test', function () {
           if (!isNaN(sig)) {
             assert.equal(err.code, sig)
           } else if (!weirdSignal(sig)) {
-            if (!process.env.TRAVIS) err.signal.should.equal(sig)
+            err.signal.should.equal(sig)
           } else if (sig) {
-            if (!process.env.TRAVIS) assert(err.signal)
+            assert(err.signal)
           }
         } else {
           assert.ifError(err)
@@ -69,8 +69,8 @@ describe('all-signals-integration-test', function () {
     var node = process.execPath
     var js = require.resolve('./fixtures/parent.js')
     it('exits properly: (external sig) ' + sig, function (done) {
-      // travis has issues with SIGUSR1 on Node 0.x.10.
-      if (process.env.TRAVIS && sig === 'SIGUSR1') return done()
+      // issues with SIGUSR1 on Node 0.10.x
+      if (process.version.match(/^v0\.10\./) && sig === 'SIGUSR1') return done()
 
       var cmd = node + ' ' + js + ' ' + sig
       exec(cmd, shell, function (err, stdout, stderr) {

--- a/test/fixtures/change-code.js
+++ b/test/fixtures/change-code.js
@@ -76,7 +76,8 @@ function listener (code, signal) {
 
 function run (opt) {
   console.error(opt)
-  exec(process.execPath + ' ' + __filename + ' ' + opt, function (err, stdout, stderr) {
+  var shell = process.platform === 'win32' ? null : { shell: '/bin/bash' }
+  exec(process.execPath + ' ' + __filename + ' ' + opt, shell, function (err, stdout, stderr) {
     var res = JSON.parse(stdout)
     if (err) {
       res.actualCode = err.code

--- a/test/multi-exit.js
+++ b/test/multi-exit.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec,
-  t = require('tap')
+  t = require('tap'),
+  shell = process.platform === 'win32' ? null : { shell: '/bin/bash' }
 
 var fixture = require.resolve('./fixtures/change-code.js')
 var expect = require('./fixtures/change-code-expect.json')
@@ -41,7 +42,7 @@ types.forEach(function (type) {
 opts.forEach(function (opt) {
   t.test(opt, function (t) {
     var cmd = process.execPath + ' ' + fixture + ' ' + opt
-    exec(cmd, function (err, stdout, stderr) {
+    exec(cmd, shell, function (err, stdout, stderr) {
       var res = JSON.parse(stdout)
       if (err) {
         res.actualCode = err.code

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -2,7 +2,8 @@
 
 var exec = require('child_process').exec,
   expect = require('chai').expect,
-  assert = require('assert')
+  assert = require('assert'),
+  shell = process.platform === 'win32' ? null : { shell: '/bin/bash' }
 
 require('chai').should()
 require('tap').mochaGlobals()
@@ -10,7 +11,7 @@ require('tap').mochaGlobals()
 describe('signal-exit', function () {
 
   it('receives an exit event when a process exits normally', function (done) {
-    exec(process.execPath + ' ./test/fixtures/end-of-execution.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/end-of-execution.js', shell, function (err, stdout, stderr) {
       expect(err).to.equal(null)
       stdout.should.match(/reached end of execution, 0, null/)
       done()
@@ -18,7 +19,7 @@ describe('signal-exit', function () {
   })
 
   it('receives an exit event when a process is terminated with sigint', function (done) {
-    exec(process.execPath + ' ./test/fixtures/sigint.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/sigint.js', shell, function (err, stdout, stderr) {
       assert(err)
       stdout.should.match(/exited with sigint, null, SIGINT/)
       done()
@@ -26,7 +27,7 @@ describe('signal-exit', function () {
   })
 
   it('receives an exit event when a process is terminated with sigterm', function (done) {
-    exec(process.execPath + ' ./test/fixtures/sigterm.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/sigterm.js', shell, function (err, stdout, stderr) {
       assert(err)
       stdout.should.match(/exited with sigterm, null, SIGTERM/)
       done()
@@ -34,7 +35,7 @@ describe('signal-exit', function () {
   })
 
   it('receives an exit event when process.exit() is called', function (done) {
-    exec(process.execPath + ' ./test/fixtures/exit.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/exit.js', shell, function (err, stdout, stderr) {
       err.code.should.equal(32)
       stdout.should.match(/exited with process\.exit\(\), 32, null/)
       done()
@@ -42,7 +43,7 @@ describe('signal-exit', function () {
   })
 
   it('does not exit if user handles signal', function (done) {
-    exec(process.execPath + ' ./test/fixtures/signal-listener.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/signal-listener.js', shell, function (err, stdout, stderr) {
       assert(err)
       assert.equal(stdout, 'exited calledListener=4, code=null, signal="SIGHUP"\n')
       done()
@@ -50,7 +51,7 @@ describe('signal-exit', function () {
   })
 
   it('ensures that if alwaysLast=true, the handler is run last (signal)', function (done) {
-    exec(process.execPath + ' ./test/fixtures/signal-last.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/signal-last.js', shell, function (err, stdout, stderr) {
       assert(err)
       stdout.should.match(/first counter=1/)
       stdout.should.match(/last counter=2/)
@@ -59,7 +60,7 @@ describe('signal-exit', function () {
   })
 
   it('ensures that if alwaysLast=true, the handler is run last (normal exit)', function (done) {
-    exec(process.execPath + ' ./test/fixtures/exit-last.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/exit-last.js', shell, function (err, stdout, stderr) {
       assert.ifError(err)
       stdout.should.match(/first counter=1/)
       stdout.should.match(/last counter=2/)
@@ -68,7 +69,7 @@ describe('signal-exit', function () {
   })
 
   it('works when loaded multiple times', function (done) {
-    exec(process.execPath + ' ./test/fixtures/multiple-load.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/multiple-load.js', shell, function (err, stdout, stderr) {
       assert(err)
       stdout.should.match(/first counter=1, code=null, signal="SIGHUP"/)
       stdout.should.match(/first counter=2, code=null, signal="SIGHUP"/)
@@ -80,7 +81,7 @@ describe('signal-exit', function () {
 
   // TODO: test on a few non-OSX machines.
   it('removes handlers when fully unwrapped', function (done) {
-    exec(process.execPath + ' ./test/fixtures/unwrap.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/unwrap.js', shell, function (err, stdout, stderr) {
       // on Travis CI no err.signal is populated but
       // err.code is 129 (which I think tends to be SIGHUP).
       var expectedCode = process.env.TRAVIS ? 129 : null
@@ -93,14 +94,14 @@ describe('signal-exit', function () {
   })
 
   it('does not load() or unload() more than once', function (done) {
-    exec(process.execPath + ' ./test/fixtures/load-unload.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/load-unload.js', shell, function (err, stdout, stderr) {
       assert.ifError(err)
       done()
     })
   })
 
   it('handles uncatchable signals with grace and poise', function (done) {
-    exec(process.execPath + ' ./test/fixtures/sigkill.js', function (err, stdout, stderr) {
+    exec(process.execPath + ' ./test/fixtures/sigkill.js', shell, function (err, stdout, stderr) {
       assert.ifError(err)
       done()
     })

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -82,13 +82,9 @@ describe('signal-exit', function () {
   // TODO: test on a few non-OSX machines.
   it('removes handlers when fully unwrapped', function (done) {
     exec(process.execPath + ' ./test/fixtures/unwrap.js', shell, function (err, stdout, stderr) {
-      // on Travis CI no err.signal is populated but
-      // err.code is 129 (which I think tends to be SIGHUP).
-      var expectedCode = process.env.TRAVIS ? 129 : null
-
       assert(err)
-      if (!process.env.TRAVIS) err.signal.should.equal('SIGHUP')
-      expect(err.code).to.equal(expectedCode)
+      err.signal.should.equal('SIGHUP')
+      expect(err.code).to.equal(null)
       done()
     })
   })


### PR DESCRIPTION
Fix #14 by avoiding Dash on Ubuntu systems.

As it happens, this module was working just fine, but the exec shell was exiting in a way that didn't match the exit of its last job.